### PR TITLE
get rid of deprecated warnings on ruby 2.7

### DIFF
--- a/doi2bib
+++ b/doi2bib
@@ -32,9 +32,9 @@ end
 
 for doi,i in ARGV.each_with_index
   doi = trim_if_url(doi)
-  url = URI.encode("#{base_url}/#{doi}")
+  url = URI::Parser.new.escape("#{base_url}/#{doi}")
   begin
-    open(url,
+    URI.open(url,
          "Accept" => "application/x-bibtex; charset=utf-8",
          :ssl_verify_mode => OpenSSL::SSL::VERIFY_NONE) do |f|
       bib = f.read


### PR DESCRIPTION
When running doi2bib on Ubuntu 20.10 with Ruby 2.7, I'm getting these:

doi2bib:35: warning: URI.escape is obsolete
doi2bib:37: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open

They go away with this small patch. Feel free to integrate.